### PR TITLE
Update support.go to address nil pointer exception on error

### DIFF
--- a/core/support.go
+++ b/core/support.go
@@ -266,6 +266,7 @@ func (e *SupportExporter) Collect(ch chan<- prometheus.Metric) {
 		result, err := e.supportClient.DescribeServiceLimitsCheckResult(checkID)
 		if err != nil {
 			glog.Errorf("Cannot retrieve Trusted Advisor check results data: %v", err)
+			continue
 		}
 
 		for _, resource := range result.FlaggedResources {


### PR DESCRIPTION
Fixes a panic caused by nil pointer dereference encountered when `e.supportClient.DescribeServiceLimitsCheckResult(checkID)` errors and returns a nil result.

This can be observed in the following output:
```
I1012 22:10:16.090589       1 main.go:26] AWS Limits Exporter v0.3.0 started.
I1012 22:10:16.090904       1 support.go:172] Refreshing Trusted Advisor check 'fW7HH0l7J9'...
E1012 22:10:16.226973       1 support.go:233] Cannot retrieve Trusted Advisor check results data: SubscriptionRequiredException: AWS Premium Support Subscription is required to use this service.
        status code: 400, request id: 22a0ec40-7c20-4858-b40f-5b27d4c21ede
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x92a213]
goroutine 19 [running]:
github.com/danielfm/aws-limits-exporter/core.(*SupportExporter).Describe(0xc0001e57a0, 0xc0000da4e0)
        /build/core/support.go:236 +0x5a3
github.com/prometheus/client_golang/prometheus.(*Registry).Register.func1(0xc14680, 0xc0001e57a0, 0xc0000da4e0)
        /go/pkg/mod/github.com/prometheus/client_golang@v1.2.1/prometheus/registry.go:274 +0x3b
created by github.com/prometheus/client_golang/prometheus.(*Registry).Register
        /go/pkg/mod/github.com/prometheus/client_golang@v1.2.1/prometheus/registry.go:273 +0x154
```