### PR TITLE
Add health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR $REPO_PATH
 RUN make build
 
 # final stage
-FROM alpine
+FROM alpine:3.14
 LABEL maintainer="Daniel Martins <daniel.martins@jusbrasil.com.br>"
 WORKDIR /app
 COPY --from=build-env /build/bin/aws-limits-exporter /app/

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,5 +31,11 @@ func main() {
 	prometheus.Register(exporter)
 
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	glog.Infof("Server listening on %s", *addr)
 	glog.Fatal(http.ListenAndServe(*addr, nil))
 }


### PR DESCRIPTION
Add a new endpoint to be used by health checks. Prior to it we have the option to use the `/metrics` endpoint that is not good or to a TCP check.

I also fixed the Alpine version to 3.14 (the last one)