### PR TITLE
Add the AWS service as a label

### DIFF
--- a/core/support.go
+++ b/core/support.go
@@ -290,6 +290,9 @@ func (e *SupportExporter) Collect(ch chan<- prometheus.Metric) {
 func newServerMetric(region, subSystem, metricName, docString string, labels []string) *prometheus.Desc {
 	return prometheus.NewDesc(
 		prometheus.BuildFQName("aws", subSystem, metricName),
-		docString, labels, prometheus.Labels{"region": region},
+		docString, labels, prometheus.Labels{
+			"region": region,
+			"aws_service": subSystem,
+		},
 	)
 }


### PR DESCRIPTION
in order to be able to identify the limit without knowing the metric
name.

This is helpful when creating an alert for all limits within one
expression:
```
{__name__=~"aws_.*_used_total"} / {__name__=~"aws_.*_limit_total"} * 100 > 80
```